### PR TITLE
Refactor formatting logic across tests and main formatter

### DIFF
--- a/cli/src/test/kotlin/LargeFileTest.kt
+++ b/cli/src/test/kotlin/LargeFileTest.kt
@@ -1,35 +1,50 @@
 import builder.DefaultNodeBuilder
 import factory.DefaultInterpreterFactory
 import factory.DefaultLexerFactory
-
 import factory.StringSplitterFactory
 import factory.StringToTokenConverterFactory
 import java.io.BufferedReader
-import java.io.ByteArrayOutputStream
 import java.io.FileReader
 import java.io.PrintStream
+import java.util.logging.Logger
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import parser.factory.DefaultParserFactory
 import parser.stream.ParserAstStream
 import stream.token.LexerTokenStream
+import type.Version
 
 class LargeFileTest {
 
-//    private val filePath = "src/test/resources/VerySmallFile.txt"
-    private val filePath = "src/test/resources/VeryLargeFile.txt"
+    companion object {
+        private val logger = Logger.getLogger(LargeFileTest::class.java.name)
+    }
 
-    private val fileLines = 32 * 1024 // 2976  // 11912
+    private val filePath = "src/test/resources/PrintLogger.txt"
+    private val fileLines = 32 * 1024 * 1024
 
     fun createFile() {
         LargeScriptCreator().create(filePath, fileLines)
     }
 
+    fun createPrintFile() {
+        LargeScriptCreator().createPrintFile(filePath, fileLines)
+    }
+
     @Test
     fun `Very Large File Should Pass Interpreter Test Style`() {
-        val outputStream = ByteArrayOutputStream()
-        System.setOut(PrintStream(outputStream))
+        val printedLines = mutableListOf<String>()
+        val printStream = object : PrintStream(System.out) {
+            override fun println(x: String?) {
+                printedLines.add(x ?: "")
+            }
+
+            override fun print(x: String?) {
+                printedLines.add(x ?: "")
+            }
+        }
+        System.setOut(printStream)
         val reader = BufferedReader(FileReader(filePath))
         createFile()
         val lexer =
@@ -46,129 +61,28 @@ class LargeFileTest {
         assertTrue(result.interpretedCorrectly, "The program should have executed successfully.")
         assertEquals("Program executed successfully", result.message)
 
-        val printed = outputStream.toString().trim()
+        val printed = printedLines.joinToString("\n").trim()
         assertEquals("$fileLines", printed)
     }
 
-//    @Test
-//    fun `Very Large File Should Pass Parser and Lexer And Log ASTs`() {
-//        val outputStream = ByteArrayOutputStream()
-//        createFile()
-//        System.setOut(PrintStream(outputStream))
-//        val reader = BufferedReader(FileReader(filePath))
-//        val lexer =
-//            DefaultLexerFactory(
-//                StringSplitterFactory,
-//                StringToTokenConverterFactory,
-//            ).createVersionOnePointOne(reader)
-//        val tokenStream = LexerTokenStream(lexer)
-//        val parser = DefaultParserFactory().createDefault(DefaultNodeBuilder(), tokenStream)
-//        val astStream = ParserAstStream(parser)
-//
-//        val loggerFile = File("src/test/resources/ParserLogger.txt")
-//        loggerFile.writeText("")
-//
-//        var currentStream = astStream
-//        var statementCount = 0
-//        while (!currentStream.isAtEnd()) {
-//            try {
-//                val astResult = currentStream.next()
-//                FileWriter(loggerFile, true).use { it.write(astResult.node.toString() + "\n") }
-//                currentStream = astResult.nextStream as ParserAstStream
-//                statementCount++
-//            } catch (e: Exception) {
-//                println("Parser failed on statement ${statementCount + 1}: ${e.message}")
-//                break
-//            }
-//        }
-//        statementCount += 2
-//        // This will print how many statements were actually parsed.
-//        println("Total statements parsed: $statementCount")
-//
-//        val printed = outputStream.toString().trim()
-//        assertEquals("$fileLines", printed)
-//    }
+    @Test
+    fun `Very Large File And Storage Should Not Pass`() {
+        val reader = BufferedReader(FileReader(filePath))
+        createPrintFile()
+        val lexer =
+            DefaultLexerFactory(
+                StringSplitterFactory,
+                StringToTokenConverterFactory,
+            ).createVersionOnePointOne(reader)
+        val tokenStream = LexerTokenStream(lexer)
+        val parser = DefaultParserFactory().createDefault(DefaultNodeBuilder(), tokenStream)
+        val astStream = ParserAstStream(parser)
+        val emitter = PrintCollector()
+        val interpreter = DefaultInterpreterFactory().createWithVersionAndEmitter(Version.VERSION_1_1, emitter)
+        val result = interpreter.interpret(astStream)
 
-//    @Test
-//    fun `Very Large File Should Log All Tokens From TokenStream`() {
-//        val outputStream = ByteArrayOutputStream()
-//        createFile()
-//        System.setOut(PrintStream(outputStream))
-//        val reader = BufferedReader(FileReader(filePath))
-//        val lexer =
-//            DefaultLexerFactory(
-//                StringSplitterFactory,
-//                StringToTokenConverterFactory,
-//            ).createVersionOnePointOne(reader)
-//        val tokenStream = LexerTokenStream(lexer)
-//
-//        val loggerFile = File("src/test/resources/logger.txt")
-//        loggerFile.writeText("")
-//
-//        var currentStream = tokenStream
-//        var tokenCount = 0
-//        var lastToken: Token? = null
-//        while (!currentStream.isAtEnd()) {
-//            val token = currentStream.peak()
-//            if (token != null) {
-//                FileWriter(loggerFile, true).use { it.write(token.toString() + "\n") }
-//                lastToken = token
-//                tokenCount++
-//            }
-//            currentStream = currentStream.next()?.nextStream as? LexerTokenStream ?: break
-//        }
-//
-//        println("Total tokens: $tokenCount")
-//        println("Last token: $lastToken")
-//
-//        val printed = outputStream.toString().trim()
-//        assertEquals("$fileLines", printed)
-//    }
-//
-//    @Test
-//    fun `Very Large File Should Log Nodes from Mock TokenStream`() {
-//        val outputStream = ByteArrayOutputStream()
-//        createFile()
-//        System.setOut(PrintStream(outputStream))
-//        val reader = BufferedReader(FileReader(filePath))
-//        val lexer =
-//            DefaultLexerFactory(
-//                StringSplitterFactory,
-//                StringToTokenConverterFactory,
-//            ).createVersionOnePointOne(reader)
-//
-//        val tokenList = mutableListOf<Token>()
-//        val tokenStream = LexerTokenStream(lexer)
-//        var currentStream = tokenStream
-//        while (!currentStream.isAtEnd()) {
-//            val token = currentStream.peak()
-//            if (token != null) {
-//                tokenList.add(token)
-//            }
-//            currentStream = currentStream.next()?.nextStream as? LexerTokenStream ?: break
-//        }
-//
-//        val mockTokenStream = MockTokenStream(tokenList)
-//
-//        val loggerFile = File("src/test/resources/MockTokenStreamLogger.txt")
-//        loggerFile.writeText("")
-//
-//        val parser = DefaultParserFactory().createDefault(DefaultNodeBuilder(), mockTokenStream)
-//        var astStream = ParserAstStream(parser)
-//        var statementCount = 0
-//        while (!astStream.isAtEnd()) {
-//            try {
-//                val astResult = astStream.next()
-//                FileWriter(loggerFile, true).use { it.write(astResult.node.toString() + "\n") }
-//                astStream = astResult.nextStream as ParserAstStream
-//                statementCount++
-//            } catch (e: Exception) {
-//                println("Parser failed on statement ${statementCount + 1}: ${e.message}")
-//                break
-//            }
-//        }
-//        println("Total statements parsed: $statementCount")
-//        val printed = outputStream.toString().trim()
-//        assertEquals("$fileLines", printed)
-//    }
+        assertTrue(result.interpretedCorrectly, "The program should have executed successfully.")
+        assertEquals("Program executed successfully", result.message)
+        emitter.messages.forEach { message -> logger.info(message) }
+    }
 }

--- a/cli/src/test/kotlin/LargeScriptCreator.kt
+++ b/cli/src/test/kotlin/LargeScriptCreator.kt
@@ -14,4 +14,15 @@ class LargeScriptCreator {
             writer.appendLine("println(x);")
         }
     }
+
+    fun createPrintFile(
+        fileName: String,
+        numberOfLines: Int,
+    ) {
+        File(fileName).bufferedWriter().use { writer ->
+            for (i in 1..numberOfLines) {
+                writer.appendLine("println(\"line $i\");")
+            }
+        }
+    }
 }

--- a/cli/src/test/kotlin/PrintCollector.kt
+++ b/cli/src/test/kotlin/PrintCollector.kt
@@ -1,0 +1,15 @@
+import emitter.Emitter
+import result.InterpreterResult
+
+class PrintCollector : Emitter {
+    val messages: MutableList<String?> = ArrayList<String?>()
+
+    override fun emit(value: InterpreterResult) {
+        messages.add(value.message)
+    }
+
+    override fun stringEmit(value: String) {
+        messages.add(value)
+    }
+
+}

--- a/formatter/src/main/kotlin/DefaultFormatter.kt
+++ b/formatter/src/main/kotlin/DefaultFormatter.kt
@@ -21,16 +21,18 @@ class DefaultFormatter(
                 .first { it.matches(stmt) }
                 .apply(stmt, sb, config, 0)
         }
-        return sb
-            .toString()
-            .lines()
-            .joinToString("\n") { line ->
-                val indent = line.takeWhile { it == ' ' }
-                indent +
-                    line
-                        .drop(indent.length)
-                        .replace(formatter.config.FormatterConstants.MULTI_SPACE_REGEX, " ")
-            }
+        val result =
+            sb
+                .toString()
+                .lines()
+                .joinToString("\n") { line ->
+                    val indent = line.takeWhile { it == ' ' }
+                    indent +
+                            line
+                                .drop(indent.length)
+                                .replace(formatter.config.FormatterConstants.MULTI_SPACE_REGEX, " ")
+                }
+        return result.removeSuffix("\n")
     }
 
     override fun formatToWriter(

--- a/formatter/src/test/kotlin/DefaultFormatterTest.kt
+++ b/formatter/src/test/kotlin/DefaultFormatterTest.kt
@@ -30,7 +30,7 @@ class DefaultFormatterTest {
         val program = builder.buildProgramNode(listOf(decl))
         val result = fmt.formatToString(program, FormatConfig())
 
-        assertEquals("let x: number;\n", result)
+        assertEquals("let x: number;", result)
     }
 
     @Test
@@ -45,7 +45,7 @@ class DefaultFormatterTest {
         val program = builder.buildProgramNode(listOf(assign))
         val result = fmt.formatToString(program, config)
 
-        assertEquals("a=42;\n", result)
+        assertEquals("a=42;", result)
     }
 
     @Test
@@ -59,7 +59,7 @@ class DefaultFormatterTest {
         val program = builder.buildProgramNode(listOf(printStmt))
         val result = fmt.formatToString(program, config)
 
-        assertEquals("\nprintln(\"hi\");\n", result)
+        assertEquals("\nprintln(\"hi\");", result)
     }
 
     @Test
@@ -85,7 +85,7 @@ class DefaultFormatterTest {
         val program = builder.buildProgramNode(listOf(decl))
         val result = fmt.formatToString(program, config)
 
-        assertEquals("let msg :string = \"ok\";\n", result)
+        assertEquals("let msg :string = \"ok\";", result)
     }
 
     @Test
@@ -102,7 +102,7 @@ class DefaultFormatterTest {
 
         fmt.formatToWriter(program, FormatConfig(), writer)
 
-        assertEquals("let x: number;\n", writer.toString())
+        assertEquals("let x: number;", writer.toString())
     }
 
     @Test
@@ -118,6 +118,6 @@ class DefaultFormatterTest {
 
         fmt.formatToWriter(program, config, writer)
 
-        assertEquals("a=42;\n", writer.toString())
+        assertEquals("a=42;", writer.toString())
     }
 }

--- a/formatter/src/test/kotlin/FormatterServiceTest.kt
+++ b/formatter/src/test/kotlin/FormatterServiceTest.kt
@@ -43,7 +43,7 @@ class FormatterServiceTest {
         Files.writeString(configFile, json)
 
         val result = service.formatToString(program, version, configFile.toString())
-        assertEquals("a=42;\n", result)
+        assertEquals("a=42;", result)
     }
 
     @Test
@@ -63,6 +63,6 @@ class FormatterServiceTest {
 
         val writer = StringWriter()
         service.formatToWriter(program, version, configFile.toString(), writer)
-        assertEquals("\nprintln(\"hi\");\n", writer.toString())
+        assertEquals("\nprintln(\"hi\");", writer.toString())
     }
 }

--- a/formatter/src/test/kotlin/Version11FormatterTest.kt
+++ b/formatter/src/test/kotlin/Version11FormatterTest.kt
@@ -39,8 +39,7 @@ class Version11FormatterTest {
             if(true) {
                 println("inside");
             }
-            
-            """.trimIndent().replace("\n", "\n")
+            """.trimIndent().replace("", "")
         assertEquals(expected, result)
     }
 
@@ -72,8 +71,7 @@ class Version11FormatterTest {
             } else {
                 println("no");
             }
-            
-            """.trimIndent().replace("\n", "\n")
+            """.trimIndent().replace("", "")
         assertEquals(expected, result)
     }
 
@@ -97,8 +95,7 @@ class Version11FormatterTest {
             if(true) {
               println("X");
             }
-            
-            """.trimIndent().replace("\n", "\n")
+            """.trimIndent().replace("", "")
         assertEquals(expected, result)
     }
 
@@ -120,7 +117,7 @@ class Version11FormatterTest {
         val formatter = FormatterFactory.createWithVersion(transform("1.1"))
         val result = formatter.formatToString(program, FormatConfig())
 
-        assertEquals("const pi: number = 3.14;\n", result)
+        assertEquals("const pi: number = 3.14;", result)
     }
 
     @Test
@@ -150,8 +147,7 @@ class Version11FormatterTest {
             if(true) {
                 const a: number = 1;
             }
-
-            """.trimIndent().replace("\n", "\n")
+            """.trimIndent().replace("", "")
         assertEquals(expected, result)
     }
 
@@ -185,7 +181,6 @@ class Version11FormatterTest {
                     println("inner");
                 }
             }
-            
             """.trimIndent()
         assertEquals(expected, result)
     }
@@ -214,7 +209,6 @@ class Version11FormatterTest {
             
                 println("inside");
             }
-            
             """.trimIndent()
         assertEquals(expected, result)
     }
@@ -260,7 +254,6 @@ class Version11FormatterTest {
             } else {
               let x :number=1;
             }
-            
             """.trimIndent()
         assertEquals(expected, result)
     }
@@ -277,7 +270,7 @@ class Version11FormatterTest {
         val formatter = FormatterFactory.createWithVersion(transform("1.1"))
 
         val result = formatter.formatToString(program, config)
-        assertEquals("\n\nprintln(\"test\");\n", result)
+        assertEquals("\n\nprintln(\"test\");", result)
     }
 
     @Test
@@ -292,7 +285,7 @@ class Version11FormatterTest {
         val formatter = FormatterFactory.createWithVersion(transform("1.1"))
 
         val result = formatter.formatToString(program, config)
-        assertEquals("println(\"test\");\n", result)
+        assertEquals("println(\"test\");", result)
     }
 
     @Test
@@ -308,6 +301,6 @@ class Version11FormatterTest {
         val formatter = FormatterFactory.createWithVersion(transform("1.1"))
 
         val result = formatter.formatToString(program, FormatConfig())
-        assertEquals("const pi: number;\n", result)
+        assertEquals("const pi: number;", result)
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@
 # https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_configuration_properties
 org.gradle.configuration-cache=false
 group=com.github.tef-austral
-version=1.1.23
+version=1.1.24

--- a/interpreter/src/main/kotlin/factory/DefaultInterpreterFactory.kt
+++ b/interpreter/src/main/kotlin/factory/DefaultInterpreterFactory.kt
@@ -46,4 +46,16 @@ class DefaultInterpreterFactory : InterpreterFactory {
                     inputProvider,
                 )
         }
+
+    fun createWithVersionAndEmitter(
+        version: Version,
+        emitter: Emitter,
+    ): Interpreter =
+        when (version) {
+            Version.VERSION_1_0 -> InterpreterFactoryVersionOne.createDefaultInterpreter(emitter)
+            Version.VERSION_1_1 ->
+                InterpreterFactoryVersionOnePointOne.createDefaultInterpreter(
+                    emitter
+                )
+        }
 }


### PR DESCRIPTION
- Consolidated newline removal in formatter logic by using `removeSuffix("\n")`.
- Updated test cases in `FormatterServiceTest` and `DefaultFormatterTest` for consistent formatting expectations.
- Enhanced `LargeFileTest` to include new `createPrintFile` and `PrintCollector`.
- Added `createWithVersionAndEmitter` method to `DefaultInterpreterFactory` for expanded use cases.
- Introduced `PrintCollector` for capturing emitted messages.
- Bumped version to 1.1.24 in `gradle.properties`.